### PR TITLE
Add app host to the env secrets after launch

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,6 +46,9 @@ if ! flyctl status --app "$app"; then
   # Launch new app
   flyctl launch --no-deploy --copy-config --name "$app" --region "$region" --org "$org" --remote-only
 
+  # Add app host to env secrets
+  flyctl secrets set --app "$app" PHX_HOST="$app".fly.dev
+
   if [ -n "$INPUT_POSTGRES" ]; then
     # Attach app to postgres database
     flyctl postgres attach --app "$app" "$INPUT_POSTGRES" || true


### PR DESCRIPTION
This change fixes the inability of Phoenix to connect to the live socket of a deployed PR.

This inability arises because we deploy each pr to a different host (`pr-{PR_NUMBER}-{REPO_NAME}.fly.dev`). After deployment, Phoenix first checks if a host is added to the env secrets of the deployment. If it isn't, it gets the host from the config file `fly.toml` (*The host specified in this file is usually that of the main app deployment*). Phoenix then attempts a socket connection to this host, but because it is for the main app and not the pr, the socket connection fails.

This change fixes this by adding the host of each PR deployment to the app's env secrets. 