### PR TITLE
Skip prompts in preview workflow

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,7 +52,7 @@ if ! flyctl status --app "$app"; then
 
   if [ -n "$INPUT_POSTGRES" ]; then
     # Attach app to postgres cluster and database.
-    flyctl postgres attach --app "$app" "$INPUT_POSTGRES" --database-name "$database" || true
+    flyctl postgres attach --app "$app" "$INPUT_POSTGRES" --database-name "$database" --yes || true
   fi
 
   # Restore the original config file


### PR DESCRIPTION
Previously, the command that attaches preview apps to the db brings up a prompt that the db already exists and if we should continue, but the prompt cannot be acted upon in the workflow. This fix adds the `--yes` flag to the command to accepts all confirmations and prevent the prompt from coming up.