### PR TITLE
Add `fly postgres detach` before `fly apps destroy`

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,6 +31,19 @@ fi
 
 # PR was closed - remove the Fly app if one exists and exit.
 if [ "$EVENT_TYPE" = "closed" ]; then
+  if [ -n "$INPUT_POSTGRES" ]; then
+    apk add expect
+
+    # Detach app from postgres cluster and database.
+    expect -c "
+      spawn flyctl postgres detach "$INPUT_POSTGRES" --app "$app"
+      expect {Select the attachment that you would like to detach*}
+      send -- \"\r\"
+      expect eof
+    "
+  fi
+
+  # Destroy the Fly app
   flyctl apps destroy "$app" -y || true
   exit 0
 fi


### PR DESCRIPTION
This `fly-pr-reviews-apps` pull request is depended on this [workflow](https://github.com/projectstake/workflows/pull/43).

`fly postgres detach` removes the `<app-name>` user from the Postgres cluster, and the `DATABASE_URL` secret from the `<app-name>` app. 

This ensures the removal of the database user and connected database associated with the app before executing the `flyctl apps destroy` command.

Closes #11