### PR TITLE
Install `build-base`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN apk --no-cache add git
 
 RUN which git
 
+RUN apk --no-cache --update add build-base
+
 COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This is the equivalent of `build-essential` and is needed to compile `bcrypt_elixir` when `fly launch` is executed.

Here is a [sample pr application](https://pr-326-projectstake-chainstaker.fly.dev/) that has been deployed through this pipeline.

Closes #17