### PR TITLE
Reassign db objects before dropping user

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -78,6 +78,9 @@ if ! echo "$secrets" | grep -q "DATABASE_URL"; then
 
     # Execute DROP USER command using flyctl postgres connect
     eval "flyctl postgres connect -a "$INPUT_POSTGRES" <<EOF
+    \c $database;
+    REASSIGN OWNED BY $postgres_user TO postgres;
+    DROP OWNED BY $postgres_user;
     DROP USER $postgres_user;
     \q
     EOF"


### PR DESCRIPTION
In the current review app deployment implementation, before launching a pull request app, any user with the PR app name in the PostgreSQL cluster is first dropped, but what if a user cannot be dropped because it owns some database objects (such as tables, views, functions, etc.)? In this case, these objects need to be reassigned to a reliable user like postgres before dropping the user.

Closes #19 